### PR TITLE
Fix #4: Does not compile on x86_64

### DIFF
--- a/pcd/src/except.c
+++ b/pcd/src/except.c
@@ -164,7 +164,6 @@ static void PCD_dump_maps_file( pid_t pid )
     struct stat fbuf;
     char mapsFile[ 22 ];
     int32_t fd;
-	int32_t i;
 
     sprintf( mapsFile, "%s/%d.maps", CONFIG_PCD_TEMP_PATH, pid );
 
@@ -179,12 +178,12 @@ static void PCD_dump_maps_file( pid_t pid )
         char buffer[ 512 ];
         int32_t readBytes = 0;
 
-        i = write( STDERR_FILENO, "\nMaps file:\n\n", 13 );
+        write( STDERR_FILENO, "\nMaps file:\n\n", 13 );
 
         /* Read the maps file and display it on the console */
         while ( ( readBytes = read( fd, buffer, sizeof( buffer ) ) ) > 0 )
         {
-            i = write( STDERR_FILENO, buffer, readBytes );
+            write( STDERR_FILENO, buffer, readBytes );
         }
 
         close( fd );

--- a/pcd/src/pcd_api.c
+++ b/pcd/src/pcd_api.c
@@ -110,7 +110,7 @@ static PCD_status_e PCD_api_signal( rule_t *rule, int32_t sig )
 PCD_status_e PCD_api_init( void )
 {
     /* Init IPC */
-    if ( IPC_init( 0 ) != PCD_STATUS_OK )
+    if ( IPC_init( 0 ) != IPC_STATUS_OK )
     {
         PCD_PRINTF_STDERR( "Failed to init PCD API");
 
@@ -118,7 +118,7 @@ PCD_status_e PCD_api_init( void )
     }
 
     /* Start IPC */
-    if ( IPC_start( CONFIG_PCD_SERVER_NAME, &pcdContext, 0 ) != PCD_STATUS_OK )
+    if ( IPC_start( CONFIG_PCD_SERVER_NAME, &pcdContext, 0 ) != IPC_STATUS_OK )
     {
         PCD_PRINTF_STDERR( "Failed to start IPC" );
 
@@ -126,7 +126,7 @@ PCD_status_e PCD_api_init( void )
     }
 
     /* Set owner */
-    if ( IPC_set_owner( pcdContext, CONFIG_PCD_OWNER_ID ) != PCD_STATUS_OK )
+    if ( IPC_set_owner( pcdContext, CONFIG_PCD_OWNER_ID ) != IPC_STATUS_OK )
     {
         IPC_stop( pcdContext );
 
@@ -162,7 +162,7 @@ PCD_status_e PCD_api_check_messages( void )
         IPC_context_t msgContext;
 
         /* Check if we need to reply */
-        if ( IPC_get_msg_context( msg, &msgContext ) == PCD_STATUS_OK )
+        if ( IPC_get_msg_context( msg, &msgContext ) == IPC_STATUS_OK )
         {
             /* Allocate memory for reply message */
             replyMsg = IPC_alloc_msg( pcdContext, sizeof( pcdApiReplyMessage_t ) );
@@ -324,7 +324,7 @@ PCD_status_e PCD_api_check_messages( void )
             replyData->retval = retval;
 
             /* Send response */
-            if ( IPC_reply_msg( msg, replyMsg ) != PCD_STATUS_OK )
+            if ( IPC_reply_msg( msg, replyMsg ) != IPC_STATUS_OK )
             {
                 IPC_free_msg( replyMsg );
             }
@@ -358,7 +358,7 @@ void PCD_api_reply_message( void *cookie, PCD_status_e retval )
     data = IPC_get_msg( msg );
 
     /* Check if we need to reply */
-    if ( IPC_get_msg_context( msg, &msgContext ) == PCD_STATUS_OK )
+    if ( IPC_get_msg_context( msg, &msgContext ) == IPC_STATUS_OK )
     {
         /* Allocate memory for reply message */
         replyMsg = IPC_alloc_msg( pcdContext, sizeof( pcdApiReplyMessage_t ) );
@@ -382,7 +382,7 @@ void PCD_api_reply_message( void *cookie, PCD_status_e retval )
         replyData->retval = retval;
 
         /* Send response */
-        if ( IPC_reply_msg( msg, replyMsg ) != PCD_STATUS_OK )
+        if ( IPC_reply_msg( msg, replyMsg ) != IPC_STATUS_OK )
         {
             PCD_PRINTF_STDERR( "Failed to send termination reply message" );
             IPC_free_msg( replyMsg );

--- a/pcd/src/pcdapi/src/pcdapi.c
+++ b/pcd/src/pcdapi/src/pcdapi.c
@@ -110,7 +110,7 @@ static PCD_status_e PCD_api_malloc_and_send( const struct ruleId_t *ruleId, pcdA
         pcdApiInitDone = True;
     }
 
-    if ( IPC_get_context_by_owner( &pcdCtx, CONFIG_PCD_OWNER_ID ) != PCD_STATUS_OK )
+    if ( IPC_get_context_by_owner( &pcdCtx, CONFIG_PCD_OWNER_ID ) != IPC_STATUS_OK )
     {
         printf( "pcd: Error: Failed to find PCD context\n");       
         return PCD_STATUS_INVALID_RULE;
@@ -119,7 +119,7 @@ static PCD_status_e PCD_api_malloc_and_send( const struct ruleId_t *ruleId, pcdA
     sprintf( pcdClient, CONFIG_PCD_CLIENTS_NAME_PREFIX "%d", getpid() );
 
     /* Create temporary destination point */
-    if ( IPC_start( pcdClient, &pcdTmpCtx, 0) != PCD_STATUS_OK )
+    if ( IPC_start( pcdClient, &pcdTmpCtx, 0) != IPC_STATUS_OK )
     {
         printf( "pcd: Error: Failed to start IPC\n");
         return PCD_STATUS_NOK;

--- a/pcd/src/process.c
+++ b/pcd/src/process.c
@@ -62,6 +62,8 @@
 #include "pcd_api.h"
 #include "ipc.h"
 
+#include "sys/resource.h"
+
 /**************************************************************************/
 /*      LOCAL DEFINITIONS AND VARIABLES                                   */
 /**************************************************************************/
@@ -1011,10 +1013,9 @@ void PCD_process_reboot( void )
     else
     {
         const char msg[]= "pcd: Reboot disabled in debug mode, exiting.\n";
-        int32_t i;
 		
         /* Display reboot message */
-        i = write( STDERR_FILENO, msg, sizeof(msg) );
+        write( STDERR_FILENO, msg, sizeof(msg) );
 
         /* Exit abnormally */
         exit( 1 );


### PR DESCRIPTION
**RCA**
Missing header include.

**FIX**
- Added the missing includes (sys/resource.h)
- Resolved the warnings as well

**TEST**
Here is my compilation output:
```
$ make
*--------------------------------------------------
*  Process Control Daemon
*  Build date: Sun, 08 Oct 2017 10:32:24 +0530 :
*--------------------------------------------------
Checking write permission: /home/rp/pcd/include
Checking write permission: /home/rp/pcd/sbin/
Checking write permission: /home/rp/pcd
Building PCD...
make[1]: Entering directory '/home/rp/github/pcd/ipc/src'
  CC [C] 	ipc.o
  LINK	 	libipc
make[1]: Leaving directory '/home/rp/github/pcd/ipc/src'
make[1]: Entering directory '/home/rp/github/pcd/pcd/src/pcdapi/src'
  CC [C] 	pcdapi.o
  LINK	 	libpcd
make[1]: Leaving directory '/home/rp/github/pcd/pcd/src/pcdapi/src'
make[1]: Entering directory '/home/rp/github/pcd/pcd/src'
  CC [C] 	condchk.o
  CC [C] 	errlog.o
  CC [C] 	except.o
  CC [C] 	failact.o
  CC [C] 	main.o
  CC [C] 	misc.o
  CC [C] 	parser.o
  CC [C] 	pcd_api.o
  CC [C] 	process.o
  CC [C] 	rules_db.o
  CC [C] 	timer.o
  LINK	 	pcd
make[1]: Leaving directory '/home/rp/github/pcd/pcd/src'
make[1]: Entering directory '/home/rp/github/pcd/pcd/src/parser/src'
  CC [C] 	graph.o
  CC [C] 	main.o
  CC [C] 	outputhdr.o
  CC [C] 	parser.o
  LINK	 	pcdparser
make[1]: Leaving directory '/home/rp/github/pcd/pcd/src/parser/src'
PCD build completed.
```