### PR TITLE
docs: Borrowing the original documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ coverage
 # compile/build directories #
 #############################
 build/
-docs/
 .settings
 
 


### PR DESCRIPTION
The original documentation has been archived under "[rt-embedded](http://web.archive.org/web/20140220101011/http://www.rt-embedded.com/blog/pcd-process-control-daemon/)." I wanna create a github pages out of these original for the github code base.