### PR TITLE
fix: x64 compilation issue: siginfo_t and sigaction struct definitions not found

### DIFF
--- a/pcd/src/pcdapi/src/pcdapi.c
+++ b/pcd/src/pcdapi/src/pcdapi.c
@@ -60,6 +60,8 @@
 #include "pcdapi.h"
 #include "except.h"
 
+#include <signal.h>
+
 
 /*! \def PCD_API_REPLY_TIMEOUT
  *  \brief Timeout for PCD response


### PR DESCRIPTION
RCA
    - signal.h was not being included in the 'c' file.

FIX
    - added the missing include (signal.h)

TEST

    $> make clean; make
    *--------------------------------------------------
    *  Process Control Daemon
    *  Build date: Mon, 01 Oct 2018 00:59:27 +0000 :
    *--------------------------------------------------
    Checking write permission: /home/rp/pcd/include
    Checking write permission: /home/rp/pcd/bin/
    Checking write permission: /home/rp/pcd/
    Checking write permission: /home/rp/github/pcd/include
    Building PCD...
    make[1]: Entering directory '/home/rp/github/pcd/ipc/src'
      CC [C] 	ipc.o
      LINK	 	libipc
    make[1]: Leaving directory '/home/rp/github/pcd/ipc/src'
    make[1]: Entering directory '/home/rp/github/pcd/pcd/src/pcdapi/src'
      CC [C] 	pcdapi.o
      LINK	 	libpcd
    make[1]: Leaving directory '/home/rp/github/pcd/pcd/src/pcdapi/src'
    make[1]: Entering directory '/home/rp/github/pcd/pcd/src'
      CC [C] 	condchk.o
      CC [C] 	errlog.o
      CC [C] 	except.o
    /home/rp/github/pcd/pcd/src/except.c: In function ‘PCD_dump_maps_file’:
    /home/rp/github/pcd/pcd/src/except.c:181:9: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
	     write( STDERR_FILENO, "\nMaps file:\n\n", 13 );
	     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/rp/github/pcd/pcd/src/except.c:186:13: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
		 write( STDERR_FILENO, buffer, readBytes );
		 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      CC [C] 	failact.o
      CC [C] 	main.o
      CC [C] 	misc.o
      CC [C] 	parser.o
      CC [C] 	pcd_api.o
      CC [C] 	process.o
    /home/rp/github/pcd/pcd/src/process.c: In function ‘PCD_process_spawn’:
    /home/rp/github/pcd/pcd/src/process.c:525:13: warning: ignoring return value of ‘setreuid’, declared with attribute warn_unused_result [-Wunused-result]
		 setreuid( rule->uid, rule->uid );
		 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/rp/github/pcd/pcd/src/process.c: In function ‘PCD_process_reboot’:
    /home/rp/github/pcd/pcd/src/process.c:1018:9: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
	     write( STDERR_FILENO, msg, sizeof(msg) );
	     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      CC [C] 	rules_db.o
      CC [C] 	timer.o
      LINK	 	pcd
    make[1]: Leaving directory '/home/rp/github/pcd/pcd/src'
    make[1]: Entering directory '/home/rp/github/pcd/pcd/src/parser/src'
      CC [C] 	graph.o
      CC [C] 	main.o
      CC [C] 	outputhdr.o
      CC [C] 	parser.o
      LINK	 	pcdparser
    make[1]: Leaving directory '/home/rp/github/pcd/pcd/src/parser/src'
    PCD build completed.